### PR TITLE
Offload panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -379,6 +379,7 @@
     "react-hook-form": "^7.49.2",
     "react-i18next": "^15.0.0",
     "react-inlinesvg": "4.2.0",
+    "react-intersection-observer": "^9.16.0",
     "react-loading-skeleton": "3.5.0",
     "react-moveable": "0.56.0",
     "react-redux": "9.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17936,6 +17936,7 @@ __metadata:
     react-hook-form: "npm:^7.49.2"
     react-i18next: "npm:^15.0.0"
     react-inlinesvg: "npm:4.2.0"
+    react-intersection-observer: "npm:^9.16.0"
     react-loading-skeleton: "npm:3.5.0"
     react-moveable: "npm:0.56.0"
     react-redux: "npm:9.2.0"
@@ -25843,6 +25844,19 @@ __metadata:
   peerDependencies:
     react: ^16.8.4 || ^17.0.0 || ^18.0.0
   checksum: 10/5d23ad0f6f920458abd4c01af1b3cbdbe8846c254762fd6cfff4df119c54e08dd98ce8e91acacafb8173c19f07de2066df5b8e6cb19425751c1929a2620cbe77
+  languageName: node
+  linkType: hard
+
+"react-intersection-observer@npm:^9.16.0":
+  version: 9.16.0
+  resolution: "react-intersection-observer@npm:9.16.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10/ded14524d9311cfb9dd9e65eb04748d07a1868f8c40dd628bec8a8474d43ee2373604fdc1e6a7d468a8e2e680638e41b91048ab9669555d50217c5c0c51247e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR addresses frontend performance issues in Grafana dashboards caused by excessive DOM elements when rendering a large number of panels with multiple time series. Instead of rendering all panels at once, this change introduces panel virtualisation using `react-intersection-observer`, ensuring that only visible panels are mounted in the DOM.